### PR TITLE
Added unicode expression for greek letter mu to regex in magnitude dict

### DIFF
--- a/chemdataextractor/parse/quantity.py
+++ b/chemdataextractor/parse/quantity.py
@@ -28,7 +28,7 @@ magnitudes_dict = {R('c(enti)?', group=0): -2.,
                   R('G(iga)?', group=0): 9.,
                   R('T(era)?', group=0): 12.,
                   R('m(illi)?', group=0): -3.,
-                  R('µ|(micro)|(mu)', group=0): -6.,
+                  R('µ|(micro)|(mu)|\u03bc', group=0): -6.,
                   R('n(ano)?', group=0): -9.,
                   R('p(ico)?', group=0): -12.}
 


### PR DESCRIPTION
A tiny change:

In chemdataextractor/parse/quantity.py, line 31, the Unicode expression '\u03bc' for the greek character mu was added in the magnitudes_dict to make sure that the character is parsed.

Without this change, 'µ' is not automatically recognised as a magnitude. In my case, an expression with the unit "µmol" was not parsed. I am not sure if this is a system-specific issue (tested on Windows 10). Adding the Unicode expression fixed it.