### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.8-buster
+
+
+RUN pip install --no-cache-dir chemdataextractor2
+RUN pip install --no-cache-dir "numpy<1.24.0"
+
+RUN cde
+
+CMD ["/bin/bash", "-c", "bash"]


### PR DESCRIPTION
Hey there! 

As discussed in #31 with @rccc and @shohnmccullough, it might be sensible to provide a Docker image to address the dependency issues that have been introduced with the new chemical entity recognition system in version 2.1 (see #13, #24, #29, #30, #31). 

All I have done here is add a Dockerfile that specifies how to generate the image. This way, people can use CDE 2.1.2 on any operating system.