### PR TITLE
Added recognition for ratios expressed with colons

### DIFF
--- a/chemdataextractor/parse/quantity.py
+++ b/chemdataextractor/parse/quantity.py
@@ -66,7 +66,7 @@ def value_element(units=None):
     """
     pure_number = R(r'^(([\+\-–−~∼˜]?\d+(([\.・,\d])+)?)|(\<nUm\>)|(×))+$')
     spaced_power_number = pure_number + R(r'^×$') + pure_number
-    fraction = R(r'^(([\+\-–−]?\d+/\d+)|(\<nUm\>))$') | (R(r'^(([\+\-–−]?\d+)|(\<nUm\>))$') + R(r'^/$') + R(r'^((\d+)|(\<nUm\>))$')).add_action(merge)
+    fraction = R(r'^(([\+\-–−]?\d+/\d+)|(\<nUm\>))$') | R(r'^(([\+\-–−]?\d+:\d+)|(\<nUm\>))$') | (R(r'^(([\+\-–−]?\d+)|(\<nUm\>))$') + R(r'^[/:]$') + R(r'^((\d+)|(\<nUm\>))$')).add_action(merge)
     number = spaced_power_number | fraction | pure_number
     joined_range = R(r'^[\+\-–−~∼˜]?\d+(([\.・,\d])+)?[\-–−~∼˜]\d+(([\.・,\d])+)?$')('raw_value').add_action(merge)
     if units is not None:


### PR DESCRIPTION
Modified the quantity.py file to include functionality for recognizing fractions/ratios that are expressed using a colon (e.g., Molar Raio '1:2'), in addition to the existing slash-based format (e.g., '1/2').