### PR TITLE
Updated elsevier.py

### DIFF
--- a/chemdataextractor/reader/elsevier.py
+++ b/chemdataextractor/reader/elsevier.py
@@ -155,7 +155,7 @@ class ElsevierXmlReader(XmlReader):
                  'ce|grant-sponsor, ce|grant-number, prism|copyright,' \
                  'xocs|pii-unformatted, xocs|ucs-locator, ce|copyright,' \
                  'prism|publisher, prism|*, xocs|copyright-line, xocs|cp-notice,' \
-                 'dc|description, xocs|document-subtype, ce|keywords, default|openaccessType,'\
+                 'dc|description, xocs|document-subtype, default|openaccessType,'\
                  'default|openArchiveArticle, default|openaccessSponsorName, default|openaccessSponsorType, default|openaccessUserLicense, dcterms|subject,'\
                  'ce|dochead, ce|label, default|pubType'
 

--- a/tests/test_reader_elsevier.py
+++ b/tests/test_reader_elsevier.py
@@ -43,14 +43,14 @@ class TestElsXMLReader(unittest.TestCase):
         content = f.read()
         d = r.readstring(content)
         f.close()
-        self.assertEqual(len(d.elements), 139)
+        self.assertEqual(len(d.elements), 145)
 
     def test_document_usage(self):
         """Test XMLReader used via Document.from_file."""
         fname = 'j.jnoncrysol.2017.07.006.xml'
         f = io.open(os.path.join(os.path.dirname(__file__), 'data', 'elsevier', fname), 'rb')
         d = Document.from_file(f, readers=[ElsevierXmlReader()])
-        self.assertEqual(len(d.elements), 139)
+        self.assertEqual(len(d.elements), 145)
 
     def test_metadata(self):
         """Test that the retrieved metadata is correct


### PR DESCRIPTION
Reverted ignore_css to allow parsing for keywords in Elsevier documents. Changed tests accordingly.