### PR TITLE
Bump stanza to 1.6.1.

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -23,5 +23,5 @@ yaspin
 tokenizers==0.12.1
 scikit-learn==0.22.1
 allennlp==0.9.0
-stanza==1.2.0
+stanza==1.6.1
 overrides==3.1.0

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'tokenizers==0.12.1',
         'scikit-learn==0.22.1',
         'overrides==3.1.0',
-        'stanza==1.2.0',
+        'stanza==1.6.1',
     ],
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
This is the latest version that supports python 3.6

Fixes https://github.com/CambridgeMolecularEngineering/chemdataextractor2/issues/52